### PR TITLE
TableCellCoordinates removed factory checks

### DIFF
--- a/src/main/java/walkingkooka/text/pretty/TableCellCoordinates.java
+++ b/src/main/java/walkingkooka/text/pretty/TableCellCoordinates.java
@@ -26,12 +26,6 @@ final class TableCellCoordinates implements Comparable<TableCellCoordinates> {
 
     static TableCellCoordinates with(final int column,
                                      final int row) {
-        if (column < 0) {
-            throw new IllegalArgumentException("Invalid column " + column + " must be >= 0");
-        }
-        if (row < 0) {
-            throw new IllegalArgumentException("Invalid row " + column + " must be >= 0");
-        }
         return new TableCellCoordinates(column, row);
     }
 

--- a/src/test/java/walkingkooka/text/pretty/TableCellCoordinatesTest.java
+++ b/src/test/java/walkingkooka/text/pretty/TableCellCoordinatesTest.java
@@ -29,16 +29,6 @@ public final class TableCellCoordinatesTest extends TableTestCase2<TableCellCoor
     private final static int ROW = 3;
 
     @Test
-    public void testWithNegativeColumnFails() {
-        assertThrows(IllegalArgumentException.class, () -> TableCellCoordinates.with(-1, 0));
-    }
-
-    @Test
-    public void testWithNegativeRowFails() {
-        assertThrows(IllegalArgumentException.class, () -> TableCellCoordinates.with(0, -1));
-    }
-
-    @Test
     public void testDifferentColumn() {
         this.checkNotEquals(TableCellCoordinates.with(99, 3));
     }


### PR DESCRIPTION
- Checks unnecessary as other caller methods already perform.