### PR TITLE
TableNotEmpty ctor remove findWidth

### DIFF
--- a/src/main/java/walkingkooka/text/pretty/Table.java
+++ b/src/main/java/walkingkooka/text/pretty/Table.java
@@ -158,12 +158,16 @@ public abstract class Table implements TreePrintable {
                 rows.size
         );
 
+        final int width = Math.max(
+                startColumn,
+                this.width()
+        );
+
+        rows.setWidth(width);
+
         return TableNotEmpty.with(
                 rows,
-                Math.max(
-                        startColumn,
-                        this.width()
-                )
+                width
         );
     }
 
@@ -345,6 +349,7 @@ public abstract class Table implements TreePrintable {
     private TableNotEmpty setWidthDifferent(final int width) {
         final TableNotEmptyListRows rows = this.rows()
                 .copy();
+        rows.setWidth(width);
 
         return TableNotEmpty.with(
                 rows,
@@ -441,11 +446,9 @@ public abstract class Table implements TreePrintable {
                 .copy();
         rows.size = height;
 
-        final int width = rows.findWidth();
-
         return TableNotEmpty.with(
                 rows,
-                width
+                rows.findAndSetWidth()
         );
     }
 

--- a/src/main/java/walkingkooka/text/pretty/TableNotEmpty.java
+++ b/src/main/java/walkingkooka/text/pretty/TableNotEmpty.java
@@ -73,6 +73,8 @@ final class TableNotEmpty extends Table {
             row++;
         }
 
+        rows.setWidth(width);
+
         return with(
                 rows,
                 width
@@ -85,9 +87,12 @@ final class TableNotEmpty extends Table {
 
         rows.setAuto(row, rowText);
 
+        final int width = rowText.size;
+        rowText.setWidth(width);
+
         return with(
                 rows,
-                rowText.size
+                width
         );
     }
 
@@ -110,9 +115,8 @@ final class TableNotEmpty extends Table {
             throw new IllegalArgumentException("Invalid width " + width + " < 0");
         }
 
-        rows.setWidth(width);
-
         this.rows = rows;
+        rows.missing.width = width;
         this.width = width;
     }
 
@@ -264,19 +268,25 @@ final class TableNotEmpty extends Table {
 
     @Override
     Table addRow0(final int row,
-                           final TableNotEmptyListRow rowText) {
+                  final TableNotEmptyListRow rowText) {
         final TableNotEmptyListRows newRows = this.rows.copy();
         newRows.setAuto(
                 row,
                 rowText
         );
 
+        final int rowTextWidth = rowText.size;
+        int width = this.width;
+        if(rowTextWidth > width) {
+            newRows.setWidth(rowTextWidth);
+            width = rowTextWidth;
+        } else {
+            rowText.setWidth(width);
+        }
+
         return with(
                 newRows,
-                Math.max(
-                        this.width,
-                        rowText.size
-                )
+                width
         );
     }
 
@@ -293,33 +303,35 @@ final class TableNotEmpty extends Table {
             final TableNotEmptyListRows newRows = rows.copy();
             newRows.setAuto(row, rowText);
 
-            if(0 == newRows.elementCount) {
+            if (0 == newRows.elementCount) {
                 after = empty();
             } else {
                 // different row text...
                 final int currentWidth = this.width();
                 int width;
 
-                if(null ==rowText ){
+                if (null == rowText) {
                     width = currentWidth;
                 } else {
-                    if(rowText.size >= currentWidth) {
+                    width = rowText.size;
+                    if (width >= currentWidth) {
                         width = rowText.size;
+                        newRows.setWidth(width);
                     } else {
                         // previous row text was width
-                        if(previous.size == currentWidth) {
-                            width = newRows.findWidth();
+                        if (previous.size == currentWidth) {
+                            width = newRows.findAndSetWidth();
                         } else {
                             width = currentWidth;
+                            rowText.setWidth(width);
                         }
                     }
-                    rowText.setWidth(width);
                 }
 
                 after = new TableNotEmpty(
-                                newRows,
-                                width
-                        );
+                        newRows,
+                        width
+                );
             }
         }
 

--- a/src/main/java/walkingkooka/text/pretty/TableNotEmptyListRow.java
+++ b/src/main/java/walkingkooka/text/pretty/TableNotEmptyListRow.java
@@ -86,7 +86,7 @@ final class TableNotEmptyListRow extends TableNotEmptyList<CharSequence> {
         );
     }
 
-    private int width;
+    int width;
 
     @Override
     TableNotEmptyListRow copy() {

--- a/src/main/java/walkingkooka/text/pretty/TableNotEmptyListRows.java
+++ b/src/main/java/walkingkooka/text/pretty/TableNotEmptyListRows.java
@@ -52,7 +52,7 @@ final class TableNotEmptyListRows extends TableNotEmptyList<TableNotEmptyListRow
         return this.missing;
     }
 
-    private final TableNotEmptyListRow missing = TableNotEmptyListRow.alwaysEmpty();
+    final TableNotEmptyListRow missing = TableNotEmptyListRow.alwaysEmpty();
 
     @Override
     boolean isMissing(final TableNotEmptyListRow row) {
@@ -76,7 +76,7 @@ final class TableNotEmptyListRows extends TableNotEmptyList<TableNotEmptyListRow
         }
     }
 
-    int findWidth() {
+    int findAndSetWidth() {
         int width = 0;
 
         int row = this.size;
@@ -91,6 +91,8 @@ final class TableNotEmptyListRows extends TableNotEmptyList<TableNotEmptyListRow
 
             row--;
         }
+
+        this.setWidth(width);
 
         return width;
     }
@@ -112,6 +114,7 @@ final class TableNotEmptyListRows extends TableNotEmptyList<TableNotEmptyListRow
         final TableNotEmptyListRows copy = new TableNotEmptyListRows(newElements);
         copy.size = this.size;
         copy.elementCount = elementCount;
+        copy.missing.width = this.missing.width;
         return copy;
     }
 

--- a/src/test/java/walkingkooka/text/pretty/TableNotEmptyColumnListTest.java
+++ b/src/test/java/walkingkooka/text/pretty/TableNotEmptyColumnListTest.java
@@ -139,11 +139,14 @@ public final class TableNotEmptyColumnListTest extends TableTestCase2<TableNotEm
             r++;
         }
 
+        final int width = 3;
+        tableRows.setWidth(width);
+
         return TableNotEmptyColumnList.with(
                 COLUMN,
                 TableNotEmpty.with(
                         tableRows,
-                        3
+                        width
                 )
         );
     }

--- a/src/test/java/walkingkooka/text/pretty/TableNotEmptyTest.java
+++ b/src/test/java/walkingkooka/text/pretty/TableNotEmptyTest.java
@@ -2779,6 +2779,8 @@ public final class TableNotEmptyTest extends TableTestCase3<TableNotEmpty>
             row++;
         }
 
+        copiedRows.setWidth(width);
+
         return TableNotEmpty.with(
                 copiedRows,
                 width


### PR DESCRIPTION
- removes unnecessary traversing of all rows to find greatest width.
- Some use cases already have the width.